### PR TITLE
Add Mediaspace lecture videos link

### DIFF
--- a/_data/constants.yaml
+++ b/_data/constants.yaml
@@ -46,6 +46,7 @@ forum_link: "https://edstem.org/us/courses/102405/discussion"
 # "https://edstem.org/us/courses/91065/discussion"
 
 lecture_videos_link: "https://classtranscribe.illinois.edu/"
+lecture_videos_mediaspace_link: "https://mediaspace.illinois.edu/channel/System+Programming+%28CS+341%29+Fall+2026/415149702"
 # plz also modify the link in _data/navigation_bar.yaml, due to yaml cannot reference variables
 # and HTML part cannot render this kind of variable reference in string as well
 lecture_handouts: "https://github.com/angrave/CS341-Lectures-FA26"

--- a/_pages/links.md
+++ b/_pages/links.md
@@ -6,7 +6,8 @@ title: Useful Links
 ## Lectures
 
 Lecture videos: [https://classtranscribe.illinois.edu/](https://classtranscribe.illinois.edu/)  
-(For any issues related to ClassTranscribe, you'd probably get a faster response by emailing [classtranscribe@illinois.edu](mailto:classtranscribe@illinois.edu))
+(For any issues related to ClassTranscribe, you'd probably get a faster response by emailing [classtranscribe@illinois.edu](mailto:classtranscribe@illinois.edu))  
+(also available on <a href='{{ site.data.constants.lecture_videos_mediaspace_link }}' target='_blank'>Mediaspace</a>)
 
 Lecture demo code and handouts: {{ site.data.constants.lecture_handouts }}
 


### PR DESCRIPTION
## Summary
- Add `lecture_videos_mediaspace_link` constant pointing to the CS 341 Fall 2026 Mediaspace channel
- Note the Mediaspace alternative on the Lectures section of the Useful Links page

## Test plan
- Verified Jekyll data/liquid reference syntax matches existing usage in the repo